### PR TITLE
CSL file change

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-reference.csl
+++ b/libs/jasnaoe-conf/jasnaoe-reference.csl
@@ -29,8 +29,8 @@
     </choose>
   </macro>
   <macro name="author">
-    <names variable="author" delimiter="," suffix=": ">
-      <name and="text" delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all"/>
+    <names variable="author" suffix=": ">
+      <name initialize-with=". " name-as-sort-order="all" delimiter=", "/>
       <label form="short"/>
       <et-al font-style="italic"/>
     </names>

--- a/libs/jasnaoe-conf/jasnaoe-reference.csl
+++ b/libs/jasnaoe-conf/jasnaoe-reference.csl
@@ -41,10 +41,6 @@
       <else-if variable="DOI">
         <text variable="DOI" prefix="doi:" suffix=","/>
       </else-if>
-      <else-if variable="URL">
-        <text term="at"/>
-        <text variable="URL" prefix=" "/>
-      </else-if>
     </choose>
   </macro>
   <macro name="issuance">
@@ -78,6 +74,34 @@
           </choose>
           <date date-parts="year" form="text" variable="issued" suffix="."/>
         </group>
+      </else-if>
+      <else-if type="webpage document" match="any">
+        <group delimiter=", " suffix=".">
+          <text variable="publisher"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+        <choose>
+          <if variable="DOI" match="any">
+            <text variable="DOI" prefix=" https://doi.org/"/>
+          </if>
+          <else-if variable="URL">
+            <text variable="URL" prefix=" "/>
+          </else-if>
+        </choose>
+        <choose>
+          <if variable="accessed">
+            <group prefix=" (" suffix=")">
+              <text value="Accessed on"/>
+              <date variable="accessed">
+                <date-part name="year" prefix=" "/>
+                <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+                <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+              </date>
+            </group>
+          </if>
+        </choose>
       </else-if>
       <else>
         <date variable="issued" suffix=".">

--- a/references.bib
+++ b/references.bib
@@ -69,27 +69,27 @@ eprint = {
   month     = {8},
   day       = {6},
   url       = {https://www.ans.org/news/2025-08-06/article-7260/thorcon-project-takes-forward-step-in-indonesia/},
-  note      = {Accessed: 2025-08-13},
+  urldate   = {2025-08-13},
 }
 
-@misc{nemo2025,
+@online{nemo2025,
   author = {Nuclear Energy Maritime Organization},
   title = {NEMO granted NGO consultative status with IMO and IAEA, advancing nuclear maritime innovation},
   year = {2025},
   month = {7},
   url = {https://www.nemo.ngo/news/nemo-granted-ngo-consultative-status-with-imo-and-iaea%2C-advancing-nuclear-maritime-innovation},
-  note = {アクセス日: 2025年8月13日},
+  urldate = {2025-08-13},
 }
 
-@misc{IMO_MSC110_2025,
+@online{IMO_MSC110_2025,
   author = {International Maritime Organization},
   title = {Maritime Safety Committee - 110th session (MSC 110), 18-27 June 2025},
   year = {2025},
   url = {https://www.imo.org/en/MediaCentre/MeetingSummaries/Pages/msc-110th-session.aspx},
-  note = {アクセス日: 2025年8月13日},
+  urldate = {2025-08-13},
 }
 
-@misc{enecho2025,
+@online{enecho2025,
   author       = {{経済産業省 資源エネルギー庁}},
   title        = {第7次エネルギー基本計画},
   year         = {2025},
@@ -225,7 +225,7 @@ abstract = {The utilization of alternative fuels such as LNG, methanol, hydrogen
   year         = {2025},
   month        = feb,
   url          = {https://maritime-executive.com/article/china-present-design-for-containership-using-molten-salt-nuclear-reactor},
-  note         = {Accessed: 2025-08-13}
+  urldate = {2025-08-13},
 }
 
 @online{LloydsRegister2024,
@@ -235,7 +235,7 @@ abstract = {The utilization of alternative fuels such as LNG, methanol, hydrogen
   month        = aug,
   day          = {15},
   url          = {https://www.lr.org/en/knowledge/press-room/press-listing/press-release/2024/lr-and-core-power-to-conduct-next-generation-nuclear-container-ship-regulatory-study/},
-  note         = {Accessed: 2025-08-13}
+  urldate = {2025-08-13},
 }
 
 @online{ABS_HEC_LFR_2023,
@@ -245,7 +245,7 @@ abstract = {The utilization of alternative fuels such as LNG, methanol, hydrogen
   month        = jul,
   day          = {25},
   url          = {https://www.corepower.energy/news/abs-study-nuclear-maritime},
-  note         = {Accessed: 2025-08-13}
+  urldate = {2025-08-13},
 }
 
 @online{ABS_HEC_HTGR_2023,
@@ -255,7 +255,7 @@ abstract = {The utilization of alternative fuels such as LNG, methanol, hydrogen
   month        = oct,
   day          = {29},
   url          = {https://www.world-nuclear-news.org/articles/abs-sees-potential-for-nuclear-powered-lng-carriers},
-  note         = {Accessed: 2025-08-13}
+  urldate = {2025-08-13},
 }
 
 @article{ichinose_method_2022,


### PR DESCRIPTION
This pull request updates both the citation style file (`jasnaoe-reference.csl`) and the bibliography file (`references.bib`) to improve consistency and accuracy in handling online references and web resources. The main changes focus on standardizing how online sources are cited and how access dates are recorded.

**Citation style and bibliography improvements:**

*Citation style updates:*
- Improved formatting for author names in `jasnaoe-reference.csl` by removing the delimiter attribute and adjusting the name formatting for better readability.
- Enhanced handling of web resources in `jasnaoe-reference.csl` by adding a dedicated section for `webpage` and `document` types, which now includes publisher, year, DOI or URL, and access date in a standardized format.
- Removed redundant URL handling when DOI is present in `jasnaoe-reference.csl` to prevent duplicate information in references.

*Bibliography entry standardization:*
- Updated all relevant `@misc` entries in `references.bib` to `@online` and replaced the `note` field used for access dates with the standard `urldate` field for better compatibility with citation tools. This change was applied to multiple entries, including `ans2025`, `nemo2025`, `IMO_MSC110_2025`, `maritimeexecutive2025molten`, `LloydsRegister2024`, `ABS_HEC_LFR_2023`, and `ABS_HEC_HTGR_2023`. [[1]](diffhunk://#diff-a93ed9cbcceab83ad6f5202fa064cac01136e239a3fbff554838bc9af14c39ffL72-R92) [[2]](diffhunk://#diff-a93ed9cbcceab83ad6f5202fa064cac01136e239a3fbff554838bc9af14c39ffL228-R228) [[3]](diffhunk://#diff-a93ed9cbcceab83ad6f5202fa064cac01136e239a3fbff554838bc9af14c39ffL238-R238) [[4]](diffhunk://#diff-a93ed9cbcceab83ad6f5202fa064cac01136e239a3fbff554838bc9af14c39ffL248-R248) [[5]](diffhunk://#diff-a93ed9cbcceab83ad6f5202fa064cac01136e239a3fbff554838bc9af14c39ffL258-R258)